### PR TITLE
Potential fix for code scanning alert no. 2: Server-side request forgery

### DIFF
--- a/themes/gohugo-theme-ananke-2.12.0/.github/scripts/posterboy.mjs
+++ b/themes/gohugo-theme-ananke-2.12.0/.github/scripts/posterboy.mjs
@@ -29,6 +29,11 @@ process.env = { ...globalEnv, ...process.env, ...localEnv };
 
 // Configurable values
 const DISCORD_WEBHOOK = process.env.DISCORD_WEBHOOK || '';
+const DISCORD_WEBHOOK_REGEX = /^https:\/\/discord\.com\/api\/webhooks\/[0-9]+\/[A-Za-z0-9_-]+$/;
+if (!DISCORD_WEBHOOK_REGEX.test(DISCORD_WEBHOOK)) {
+  console.error(`Invalid DISCORD_WEBHOOK value: ${DISCORD_WEBHOOK}. Expected format: https://discord.com/api/webhooks/{id}/{token}`);
+  process.exit(1);
+}
 const GITHUB_DEV_TOKEN = process.env.GITHUB_DEV_TOKEN || '';
 const GITHUB_REPO = process.env.GITHUB_REPO || 'theNewDynamic/gohugo-theme-ananke';
 const GITHUB_REPO_REGEX = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;


### PR DESCRIPTION
Potential fix for [https://github.com/Lnm127/DeepDiveDS/security/code-scanning/2](https://github.com/Lnm127/DeepDiveDS/security/code-scanning/2)

To fix the issue, we need to validate the `DISCORD_WEBHOOK` value before using it in the `fetch` call. The best approach is to use an allow-list of trusted webhook URLs or validate the URL structure to ensure it matches the expected format. This ensures that even if the environment variable is tampered with, the application will not make requests to untrusted or malicious URLs.

Steps to implement the fix:
1. Define a regular expression to validate the structure of the `DISCORD_WEBHOOK` URL.
2. Validate the `DISCORD_WEBHOOK` value during initialization. If it is invalid, log an error and terminate the process.
3. Ensure that only validated URLs are used in the `fetch` call.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
